### PR TITLE
[hotfix] next.config.ts 중복 turbopack 설정 제거

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -26,14 +26,6 @@ const nextConfig: NextConfig = {
       },
     },
   },
-  turbopack: {
-    rules: {
-      '*.svg': {
-        loaders: [{ loader: '@svgr/webpack', options: { exportType: 'default' } }],
-        as: '*.js',
-      },
-    },
-  },
 };
 
 export default withNextIntl(nextConfig);


### PR DESCRIPTION
## 변경 내용
- `next.config.ts`에서 중복 선언된 `turbopack` 설정 1개를 제거했습니다.
- 기존 SVG 로더 설정은 남겨 두고, 중복만 정리했습니다.

## 수정 이유
- 빌드 과정에서 아래 타입 에러가 발생하고 있었습니다.
- `An object literal cannot have multiple properties with the same name`

## 원인
- `next.config.ts` 객체 안에 `turbopack` 프로퍼티가 두 번 선언되어 있었습니다.
- 동일한 이름의 프로퍼티를 중복 선언하면서 TypeScript가 설정 파일을 에러로 처리했습니다.

## 영향 범위
- Next.js 설정 파일 타입 에러가 해소됩니다.
- 빌드가 정상적으로 진행될 수 있도록 복구하는 hotfix입니다.

## 검증
- `./node_modules/.bin/tsc --noEmit`
- 로컬 빌드 정상 수행 확인
