### PR TITLE
feat(admin): 아티클 에디터 마크다운 붙여넣기 지원

### DIFF
--- a/src/features/admin/components/ArticleEditor/ArticleEditor.tsx
+++ b/src/features/admin/components/ArticleEditor/ArticleEditor.tsx
@@ -5,6 +5,9 @@ import StarterKit from '@tiptap/starter-kit';
 import TiptapImage from '@tiptap/extension-image';
 import Link from '@tiptap/extension-link';
 import Placeholder from '@tiptap/extension-placeholder';
+import { DOMParser as PMDOMParser } from '@tiptap/pm/model';
+import type { EditorView } from '@tiptap/pm/view';
+import { marked } from 'marked';
 import { useEffect, useRef, useState, useTransition, type ChangeEvent } from 'react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
@@ -15,6 +18,23 @@ import styles from './ArticleEditor.module.css';
 
 interface Props {
   article?: ArticleEntity;
+}
+
+function pasteMarkdown(view: EditorView, event: ClipboardEvent): boolean {
+  const clipboard = event.clipboardData;
+  if (!clipboard) return false;
+  if (clipboard.getData('text/html')) return false;
+  const plain = clipboard.getData('text/plain');
+  if (!plain) return false;
+
+  const html = marked.parse(plain, { async: false, gfm: true, breaks: false }) as string;
+
+  const dom = document.createElement('div');
+  dom.innerHTML = html;
+  const slice = PMDOMParser.fromSchema(view.state.schema).parseSlice(dom);
+  view.dispatch(view.state.tr.replaceSelection(slice).scrollIntoView());
+  event.preventDefault();
+  return true;
 }
 
 export default function ArticleEditor({ article }: Props) {
@@ -92,15 +112,18 @@ export default function ArticleEditor({ article }: Props) {
     },
     editorProps: {
       attributes: { class: styles.editorContent },
-      handlePaste: (_view, event) => {
+      handlePaste: (view, event) => {
         const items = Array.from(event.clipboardData?.items ?? []);
         const imageItem = items.find((item) => item.type.startsWith('image/'));
-        if (!imageItem) return false;
-        const file = imageItem.getAsFile();
-        if (!file) return false;
-        event.preventDefault();
-        void handleImageUpload(file);
-        return true;
+        if (imageItem) {
+          const file = imageItem.getAsFile();
+          if (file) {
+            event.preventDefault();
+            void handleImageUpload(file);
+            return true;
+          }
+        }
+        return pasteMarkdown(view, event);
       },
       handleDrop: (_view, event) => {
         const files = Array.from(event.dataTransfer?.files ?? []);
@@ -120,7 +143,10 @@ export default function ArticleEditor({ article }: Props) {
       Placeholder.configure({ placeholder: 'Enter article content in English...' }),
     ],
     content: article?.content_en ?? '',
-    editorProps: { attributes: { class: styles.editorContent } },
+    editorProps: {
+      attributes: { class: styles.editorContent },
+      handlePaste: (view, event) => pasteMarkdown(view, event),
+    },
   });
 
   const editorJa = useEditor({
@@ -130,7 +156,10 @@ export default function ArticleEditor({ article }: Props) {
       Placeholder.configure({ placeholder: '日本語で記事の内容を入力してください...' }),
     ],
     content: article?.content_ja ?? '',
-    editorProps: { attributes: { class: styles.editorContent } },
+    editorProps: {
+      attributes: { class: styles.editorContent },
+      handlePaste: (view, event) => pasteMarkdown(view, event),
+    },
   });
 
   useEffect(() => {


### PR DESCRIPTION
### **User description**
## Summary

- Tiptap StarterKit은 타이핑 중 단축 입력만 지원하고 raw 마크다운을 붙여넣으면 한 덩어리 텍스트로 들어오는 문제 해결
- `marked` + `@tiptap/pm/model`의 `DOMParser`로 plain text 마크다운을 ProseMirror 슬라이스로 변환해 삽입
- `text/html`이 있으면 Tiptap 기본 처리에 위임(Notion/웹 등 리치 소스 보호), `text/plain`만 있을 때만 마크다운으로 파싱
- KO/EN/JA 세 에디터 모두에 적용. KO 에디터는 기존 이미지 paste 처리 이후 마크다운으로 폴백

## Test plan

- [ ] `/admin/articles/new` 에서 raw 마크다운(예: `# 제목\n\n본문\n\n- 리스트\n- 항목`)을 plain text로 복사해 붙여넣으면 헤딩/리스트/강조가 모두 적용되는지 확인
- [ ] Notion 또는 일반 웹페이지에서 서식 있는 텍스트를 붙여넣었을 때 기존 동작(HTML 그대로 삽입)이 유지되는지 확인
- [ ] 본문에 이미지 클립보드 paste가 여전히 동작하는지 확인 (KO 에디터)
- [ ] EN/JA 탭에서도 마크다운 붙여넣기가 동작하는지 확인
- [ ] GFM 표/체크박스/취소선 파싱 확인
- [ ] 빈 줄로 문단을 구분한 마크다운 / 단일 줄바꿈만 있는 문단의 출력 차이 확인 (`breaks: false` 이므로 단일 줄바꿈은 공백 처리)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- 아티클 에디터에 마크다운 붙여넣기 지원

- `marked` 라이브러리로 일반 텍스트 마크다운 파싱

- `text/html` 존재 시 기존 HTML 붙여넣기 유지

- 모든 언어 에디터에 붙여넣기 핸들러 적용


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ArticleEditor.tsx</strong><dd><code>아티클 에디터에 마크다운 붙여넣기 기능 구현</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/features/admin/components/ArticleEditor/ArticleEditor.tsx

<li><code>marked</code> 라이브러리와 ProseMirror <code>DOMParser</code>를 사용하여 일반 텍스트 마크다운을 HTML로 변환하고 에디터에 <br>삽입하는 <code>pasteMarkdown</code> 함수를 새로 추가했습니다.<br> <li> 클립보드에 <code>text/html</code> 데이터가 있는 경우 Tiptap의 기본 HTML 붙여넣기 동작을 유지하도록 <br><code>pasteMarkdown</code> 함수 내에서 처리합니다.<br> <li> 한국어 에디터의 <code>handlePaste</code> 로직을 업데이트하여 이미지 붙여넣기 처리 후 마크다운 붙여넣기를 폴백으로 적용했습니다.<br> <li> 영어 및 일본어 에디터에도 <code>pasteMarkdown</code> 함수를 <code>handlePaste</code> 핸들러로 추가하여 마크다운 붙여넣기를 <br>지원합니다.


</details>


  </td>
  <td><a href="https://github.com/Digitalpresso-ai/digitalpresso-homepage/pull/41/files#diff-14552e405f6a60de3b34ffc950a9120e92167686d153d6882afee04b0d5f2af9">+38/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>