### PR TITLE
release: 아티클 에디터 마크다운 붙여넣기 반영

### DIFF
--- a/src/features/admin/components/ArticleEditor/ArticleEditor.tsx
+++ b/src/features/admin/components/ArticleEditor/ArticleEditor.tsx
@@ -5,6 +5,9 @@ import StarterKit from '@tiptap/starter-kit';
 import TiptapImage from '@tiptap/extension-image';
 import Link from '@tiptap/extension-link';
 import Placeholder from '@tiptap/extension-placeholder';
+import { DOMParser as PMDOMParser } from '@tiptap/pm/model';
+import type { EditorView } from '@tiptap/pm/view';
+import { marked } from 'marked';
 import { useEffect, useRef, useState, useTransition, type ChangeEvent } from 'react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
@@ -15,6 +18,23 @@ import styles from './ArticleEditor.module.css';
 
 interface Props {
   article?: ArticleEntity;
+}
+
+function pasteMarkdown(view: EditorView, event: ClipboardEvent): boolean {
+  const clipboard = event.clipboardData;
+  if (!clipboard) return false;
+  if (clipboard.getData('text/html')) return false;
+  const plain = clipboard.getData('text/plain');
+  if (!plain) return false;
+
+  const html = marked.parse(plain, { async: false, gfm: true, breaks: false }) as string;
+
+  const dom = document.createElement('div');
+  dom.innerHTML = html;
+  const slice = PMDOMParser.fromSchema(view.state.schema).parseSlice(dom);
+  view.dispatch(view.state.tr.replaceSelection(slice).scrollIntoView());
+  event.preventDefault();
+  return true;
 }
 
 export default function ArticleEditor({ article }: Props) {
@@ -92,15 +112,18 @@ export default function ArticleEditor({ article }: Props) {
     },
     editorProps: {
       attributes: { class: styles.editorContent },
-      handlePaste: (_view, event) => {
+      handlePaste: (view, event) => {
         const items = Array.from(event.clipboardData?.items ?? []);
         const imageItem = items.find((item) => item.type.startsWith('image/'));
-        if (!imageItem) return false;
-        const file = imageItem.getAsFile();
-        if (!file) return false;
-        event.preventDefault();
-        void handleImageUpload(file);
-        return true;
+        if (imageItem) {
+          const file = imageItem.getAsFile();
+          if (file) {
+            event.preventDefault();
+            void handleImageUpload(file);
+            return true;
+          }
+        }
+        return pasteMarkdown(view, event);
       },
       handleDrop: (_view, event) => {
         const files = Array.from(event.dataTransfer?.files ?? []);
@@ -120,7 +143,10 @@ export default function ArticleEditor({ article }: Props) {
       Placeholder.configure({ placeholder: 'Enter article content in English...' }),
     ],
     content: article?.content_en ?? '',
-    editorProps: { attributes: { class: styles.editorContent } },
+    editorProps: {
+      attributes: { class: styles.editorContent },
+      handlePaste: (view, event) => pasteMarkdown(view, event),
+    },
   });
 
   const editorJa = useEditor({
@@ -130,7 +156,10 @@ export default function ArticleEditor({ article }: Props) {
       Placeholder.configure({ placeholder: '日本語で記事の内容を入力してください...' }),
     ],
     content: article?.content_ja ?? '',
-    editorProps: { attributes: { class: styles.editorContent } },
+    editorProps: {
+      attributes: { class: styles.editorContent },
+      handlePaste: (view, event) => pasteMarkdown(view, event),
+    },
   });
 
   useEffect(() => {


### PR DESCRIPTION
### **User description**
develop을 main으로 머지합니다.

## Summary

- feat(admin): 아티클 에디터에 마크다운 붙여넣기 지원 (#41)
  - `marked` + `@tiptap/pm/model`의 `DOMParser`로 plain text 마크다운을 ProseMirror 슬라이스로 변환
  - `text/html`이 있으면 Tiptap 기본 처리에 위임(Notion/웹 등 리치 소스 보호), `text/plain`만 있을 때만 마크다운 파싱
  - KO/EN/JA 세 에디터 모두 적용 (KO는 이미지 paste 처리 후 마크다운으로 폴백)

## Test plan

- [ ] `/admin/articles/new` 에서 raw 마크다운(`# 제목`, `- 리스트`, `**볼드**` 등) 붙여넣기 → 서식이 적용되는지 확인
- [ ] Notion/웹페이지의 서식 있는 텍스트 붙여넣기 → 기존 동작(HTML 그대로) 유지 확인
- [ ] 본문에 이미지 클립보드 paste 정상 동작 확인 (KO 에디터)
- [ ] EN/JA 탭에서도 마크다운 붙여넣기 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- 아티클 에디터에 마크다운 붙여넣기 지원

- `marked`로 일반 텍스트 마크다운 파싱

- HTML 붙여넣기 우선, 마크다운으로 폴백

- 모든 언어 에디터에 기능 적용


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ArticleEditor.tsx</strong><dd><code>아티클 에디터에 마크다운 붙여넣기 기능 구현</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/features/admin/components/ArticleEditor/ArticleEditor.tsx

<li><code>marked</code> 라이브러리와 ProseMirror <code>DOMParser</code>를 임포트했습니다.<br> <li> <code>pasteMarkdown</code> 함수를 추가하여 일반 텍스트 마크다운을 HTML로 변환하고 에디터에 삽입합니다.<br> <li> 클립보드에 <code>text/html</code> 데이터가 있는 경우 Tiptap의 기본 HTML 붙여넣기 동작을 유지하도록 <br><code>pasteMarkdown</code> 함수 내에서 처리합니다.<br> <li> 한국어 에디터의 <code>handlePaste</code> 로직을 업데이트하여 이미지 붙여넣기 처리 후 마크다운 붙여넣기를 폴백으로 적용했습니다.<br> <li> 영어 및 일본어 에디터에도 <code>pasteMarkdown</code> 함수를 <code>handlePaste</code> 핸들러로 추가하여 마크다운 붙여넣기를 <br>지원합니다.


</details>


  </td>
  <td><a href="https://github.com/Digitalpresso-ai/digitalpresso-homepage/pull/42/files#diff-14552e405f6a60de3b34ffc950a9120e92167686d153d6882afee04b0d5f2af9">+38/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>