### PR TITLE
fix(header): 헤더 상하 패딩 축소 (16px → 12px)

### DIFF
--- a/components/layout/Header/Header.module.css
+++ b/components/layout/Header/Header.module.css
@@ -22,7 +22,7 @@
   justify-content: space-between;
   max-width: 1280px;
   margin: 0 auto;
-  padding: 16px 64px;
+  padding: 12px 64px;
 }
 
 /* ─── 로고 ───────────────────────────────────────────────────── */
@@ -444,7 +444,7 @@
 /* ─── 반응형: 태블릿 (≤1279px) → 햄버거 전환 ────────────────── */
 @media (max-width: 1279px) {
   .inner {
-    padding: 16px 40px;
+    padding: 12px 40px;
   }
 
   .desktopNav {
@@ -467,14 +467,14 @@
 /* ─── 반응형: 모바일 (<800px) ────────────────────────────────── */
 @media (max-width: 799px) {
   .inner {
-    padding: 16px 20px;
+    padding: 12px 20px;
   }
 }
 
 /* ─── 반응형: 소형 모바일 (≤320px) ──────────────────────────── */
 @media (max-width: 320px) {
   .inner {
-    padding: 16px 16px;
+    padding: 12px 16px;
   }
 
   .mobileNavList {


### PR DESCRIPTION
## Summary
- 헤더 `.inner` 컨테이너의 상하 패딩을 `16px` → `12px`로 축소
- 로고 크기(156x55)를 유지하면서 전체 헤더 높이를 Figma 디자인(~80px)에 맞춤
- 모든 반응형 브레이크포인트(데스크탑/태블릿/모바일/소형모바일)에 일괄 적용

## Test plan
- [ ] 데스크탑(≥1280px)에서 헤더 높이 확인
- [ ] 태블릿(≤1279px)에서 헤더 높이 확인
- [ ] 모바일(<800px)에서 헤더 높이 확인
- [ ] 스크롤 시 헤더 hide/show 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)