### PR TITLE
fix: 아티클 생성·상세 페이지 버그 수정

### DIFF
--- a/src/features/admin/components/ArticleEditor/ArticleEditor.tsx
+++ b/src/features/admin/components/ArticleEditor/ArticleEditor.tsx
@@ -73,7 +73,7 @@ export default function ArticleEditor({ article }: Props) {
   );
 
   const createArticleMutation = useCreateArticle();
-  const updateArticleMutation = useUpdateArticle(article?.id ?? '');
+  const updateArticleMutation = useUpdateArticle();
 
   const ImageWithTemp = TiptapImage.extend({
     addAttributes() {
@@ -363,14 +363,17 @@ export default function ArticleEditor({ article }: Props) {
         }
 
         await updateArticleMutation.mutateAsync({
-          title,
-          title_en: titleEn,
-          title_ja: titleJa,
-          content: nextContent,
-          content_en: editorEn?.getHTML() ?? '',
-          content_ja: editorJa?.getHTML() ?? '',
-          cover_img_url: resolvedCoverUrl,
-          category,
+          id: articleId,
+          body: {
+            title,
+            title_en: titleEn,
+            title_ja: titleJa,
+            content: nextContent,
+            content_en: editorEn?.getHTML() ?? '',
+            content_ja: editorJa?.getHTML() ?? '',
+            cover_img_url: resolvedCoverUrl,
+            category,
+          },
         });
 
         if (editor && nextContent !== content) {

--- a/src/hooks/mutations/useArticleMutations.ts
+++ b/src/hooks/mutations/useArticleMutations.ts
@@ -11,11 +11,12 @@ export function useCreateArticle() {
   });
 }
 
-export function useUpdateArticle(id: string) {
+export function useUpdateArticle() {
   const client = useQueryClient();
   return useMutation({
-    mutationFn: (body: Record<string, unknown>) => updateArticleApi(id, body),
-    onSuccess: () => {
+    mutationFn: ({ id, body }: { id: string; body: Record<string, unknown> }) =>
+      updateArticleApi(id, body),
+    onSuccess: (_, { id }) => {
       client.invalidateQueries({ queryKey: ['articles'] });
       client.invalidateQueries({ queryKey: ['article', id] });
     },


### PR DESCRIPTION
### **User description**
## Summary

- **fix(admin)**: 신규 아티클 생성 시 `useUpdateArticle` 훅이 초기화 시점에 빈 ID(`''`)를 클로저에 고정해 PUT `/api/articles/` 로 요청이 날아가 405 오류 발생하던 문제 수정 — 훅 시그니처를 `{ id, body }` 형태로 변경해 호출 시점에 올바른 ID를 전달하도록 함
- **fix(news)**: 뉴스 상세 페이지 인접 기사 네비게이션 및 페이지 전환 시 스크롤 동작 개선 (`ScrollToTopOnMount` 컴포넌트 추가)

## Test plan

- [ ] 어드민에서 **신규 아티클 생성** 후 저장 → 405 없이 정상 저장되는지 확인
- [ ] 어드민에서 **기존 아티클 수정** 후 저장 → 기존 동작 유지되는지 확인
- [ ] 뉴스 상세 페이지에서 이전/다음 기사 네비게이션 클릭 시 스크롤이 최상단으로 이동하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- `useUpdateArticle` 훅 시그니처 변경

- 훅 초기화 시 ID 고정 문제 해결

- 신규 아티클 생성 시 405 오류 수정

- `mutateAsync` 호출 시점에 올바른 ID 전달


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ArticleEditor.tsx</strong><dd><code>`ArticleEditor`에서 `useUpdateArticle` 훅 호출 방식 업데이트</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/features/admin/components/ArticleEditor/ArticleEditor.tsx

<li><code>useUpdateArticle</code> 훅 호출 시 ID를 초기 인자로 전달하지 않도록 변경했습니다.<br> <li> <code>updateArticleMutation.mutateAsync</code> 호출 시 <code>id</code>와 <code>body</code>를 포함하는 객체를 전달하도록 <br>수정했습니다.<br> <li> 이는 <code>useUpdateArticle</code> 훅의 변경된 시그니처에 맞춰 호출 방식을 업데이트한 것입니다.


</details>


  </td>
  <td><a href="https://github.com/Digitalpresso-ai/digitalpresso-homepage/pull/58/files#diff-14552e405f6a60de3b34ffc950a9120e92167686d153d6882afee04b0d5f2af9">+12/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useArticleMutations.ts</strong><dd><code>`useUpdateArticle` 훅 시그니처 및 로직 개선</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hooks/mutations/useArticleMutations.ts

<li><code>useUpdateArticle</code> 훅의 시그니처에서 <code>id</code> 인자를 제거했습니다.<br> <li> <code>mutationFn</code>이 <code>id</code>와 <code>body</code>를 포함하는 객체를 인자로 받도록 수정하여, 호출 시점에 올바른 ID를 사용하도록 <br>했습니다.<br> <li> <code>onSuccess</code> 콜백에서 업데이트된 아티클의 특정 쿼리(<code>['article', id]</code>)를 무효화하도록 로직을 개선했습니다.


</details>


  </td>
  <td><a href="https://github.com/Digitalpresso-ai/digitalpresso-homepage/pull/58/files#diff-254d21f6508596b3303da3586be36275b070c7da7424978dec8f3b8d9a78920d">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>