### PR TITLE
deploy: SITE_URL 환경변수 전환 및 기본 도메인 digitalpresso.ai로 변경

### DIFF
--- a/lib/site-url.ts
+++ b/lib/site-url.ts
@@ -1,11 +1,11 @@
-const DEFAULT_SITE_URL = 'https://digitalpresso-homepage.vercel.app'
+const DEFAULT_SITE_URL = 'https://digitalpresso.ai'
 
 function normalize(url: string): string {
   return url.endsWith('/') ? url.slice(0, -1) : url
 }
 
 export function getSiteUrl(): string {
-  const raw = process.env.NEXT_PUBLIC_SITE_URL?.trim()
+  const raw = process.env.SITE_URL?.trim()
   if (!raw) return DEFAULT_SITE_URL
 
   try {


### PR DESCRIPTION
### **User description**
## 요약

`lib/site-url.ts`의 사이트 URL 설정을 변경합니다.

- 환경변수 `NEXT_PUBLIC_SITE_URL` → `SITE_URL` (서버 전용 메타데이터/사이트맵 용도라 `NEXT_PUBLIC_` 접두사 제거)
- 기본값 `https://digitalpresso-homepage.vercel.app` → `https://digitalpresso.ai`

## 배경 (NAVER 노출 이슈)

프로덕션에 사이트 URL 환경변수가 설정돼 있지 않아 `getSiteUrl()`이 항상 `vercel.app` 기본값으로 떨어졌고, 그 결과:

- 라이브 `sitemap.xml`의 모든 URL이 `digitalpresso-homepage.vercel.app`로 출력
- canonical / og:url 도 전부 `vercel.app`을 가리킴

네이버 서치어드바이저에는 `digitalpresso.ai`로 등록·소유확인·사이트맵 제출까지 했으나, **모든 SEO 신호가 vercel.app을 가리켜 등록 도메인이 색인되지 못하는 상태**였습니다. 이 변경으로 sitemap·canonical·og:url이 `digitalpresso.ai`로 통일됩니다.

## 변경 영향

- `app/sitemap.ts`, `app/robots.ts`, `app/layout.tsx`(metadataBase) 가 공유하는 `getSiteUrl()` 한 곳만 수정 → 도메인 일괄 반영

## 배포 후 필요 작업

- [ ] Vercel 프로덕션 환경변수에 `SITE_URL=https://digitalpresso.ai` 설정 (변수명 변경됨 — 기존 `NEXT_PUBLIC_SITE_URL`은 무시됨)
- [ ] 배포 후 `https://digitalpresso.ai/sitemap.xml` 도메인 확인
- [ ] 네이버 서치어드바이저 사이트맵 재제출 + 웹페이지 수집 재요청

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- `SITE_URL` 환경변수로 전환

- 기본 도메인을 `digitalpresso.ai`로 변경

- SEO 및 사이트맵 정확성 향상

- 서버 전용 메타데이터에 올바른 도메인 적용


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>site-url.ts</strong><dd><code>사이트 URL 환경변수 및 기본 도메인 업데이트</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/site-url.ts

<li><code>DEFAULT_SITE_URL</code>을 <code>https://digitalpresso.ai</code>로 변경했습니다.<br> <li> 사이트 URL을 가져오는 환경변수 이름을 <code>NEXT_PUBLIC_SITE_URL</code>에서 <code>SITE_URL</code>로 변경했습니다.<br> <li> 이는 서버 전용 메타데이터 및 사이트맵에 올바른 도메인을 적용합니다.


</details>


  </td>
  <td><a href="https://github.com/Digitalpresso-ai/digitalpresso-homepage/pull/59/files#diff-691ea8ce1eec6c61aa1570fd294771e73dee79f0514f93cdd40da1b0f81ad1d0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>