### PR TITLE
fix(analytics): /admin 경로에서 GA 스크립트 로드 제외

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -4,6 +4,8 @@ import { notFound } from 'next/navigation';
 import { routing } from '@/i18n/routing';
 import Header from '@/components/layout/Header';
 import { Footer } from '@/components/layout/Footer/Footer';
+import GoogleAnalytics from '@/components/analytics/GoogleAnalytics';
+import GAPageTracker from '@/components/analytics/GAPageTracker';
 
 interface Props {
   children: React.ReactNode;
@@ -22,6 +24,8 @@ export default async function LocaleLayout({ children, params }: Props) {
 
   return (
     <NextIntlClientProvider messages={messages}>
+      <GoogleAnalytics />
+      <GAPageTracker />
       <div className={localeClass}>
         <Header />
         {children}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono, Noto_Sans_JP, Noto_Sans_KR } from "next/font/google";
 import localFont from "next/font/local";
-import GoogleAnalytics from "@/components/analytics/GoogleAnalytics";
-import GAPageTracker from "@/components/analytics/GAPageTracker";
 import { getSiteUrl } from "@/lib/site-url";
 import QueryProvider from "@/src/providers/QueryProvider";
 import "./globals.css";
@@ -91,8 +89,6 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} ${notoSansKR.variable} ${notoSansJP.variable} ${pretendard.variable}`}
       >
-        <GoogleAnalytics />
-        <GAPageTracker />
         <QueryProvider>{children}</QueryProvider>
       </body>
     </html>


### PR DESCRIPTION
### **User description**
## Summary

- GA 컴포넌트(`GoogleAnalytics`, `GAPageTracker`)를 root 레이아웃에서 `[locale]` 레이아웃으로 이동
- `app/admin/`은 `[locale]` 하위가 아니므로 GA 스크립트 자체가 로드되지 않음

## 원인

기존에 `pathname.startsWith('/admin')` 가드가 있었으나, GA4 Enhanced Measurement가 History API를 직접 감시하는 방식으로 자동 page_view를 전송하여 가드를 우회하고 있었음.

## Test plan

- [ ] 공개 페이지(`/`, `/news` 등) GA 페이지뷰 정상 수집 확인
- [ ] `/admin/*` 경로 접근 시 GA 네트워크 요청 없음 확인 (브라우저 DevTools → Network → `collect` 요청)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- GA 컴포넌트를 `[locale]` 레이아웃으로 이동

- `/admin` 경로에서 GA 스크립트 로드 방지

- GA4 자동 페이지뷰 추적 우회 문제 해결


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Analytics</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>layout.tsx</strong><dd><code>`[locale]` 레이아웃에 GA 컴포넌트 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/[locale]/layout.tsx

<li><code>GoogleAnalytics</code> 및 <code>GAPageTracker</code> 컴포넌트를 임포트했습니다.<br> <li> <code>LocaleLayout</code> 내부에 GA 컴포넌트 렌더링을 추가했습니다.


</details>


  </td>
  <td><a href="https://github.com/Digitalpresso-ai/digitalpresso-homepage/pull/62/files#diff-44ca66e460fac15e804a2ab56f6038ef2dd0a231881294f0a3895f9ad7624c58">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>layout.tsx</strong><dd><code>루트 레이아웃에서 GA 컴포넌트 제거</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/layout.tsx

<li><code>GoogleAnalytics</code> 및 <code>GAPageTracker</code> 컴포넌트 임포트를 제거했습니다.<br> <li> <code>RootLayout</code>에서 GA 컴포넌트 렌더링을 제거했습니다.


</details>


  </td>
  <td><a href="https://github.com/Digitalpresso-ai/digitalpresso-homepage/pull/62/files#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030b">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>