### PR TITLE
Develop

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -4,6 +4,8 @@ import { notFound } from 'next/navigation';
 import { routing } from '@/i18n/routing';
 import Header from '@/components/layout/Header';
 import { Footer } from '@/components/layout/Footer/Footer';
+import GoogleAnalytics from '@/components/analytics/GoogleAnalytics';
+import GAPageTracker from '@/components/analytics/GAPageTracker';
 
 interface Props {
   children: React.ReactNode;
@@ -22,6 +24,8 @@ export default async function LocaleLayout({ children, params }: Props) {
 
   return (
     <NextIntlClientProvider messages={messages}>
+      <GoogleAnalytics />
+      <GAPageTracker />
       <div className={localeClass}>
         <Header />
         {children}

--- a/app/[locale]/news/article/[id]/page.tsx
+++ b/app/[locale]/news/article/[id]/page.tsx
@@ -8,10 +8,63 @@ import {
   getAdjacentArticles,
 } from '@/backend/article/application/server-facade';
 import { mapCmsArticleToNewsArticle } from '@/src/features/news/mappers/article.mapper';
-import { buildPageMetadata, isAppLocale, type AppLocale } from '@/lib/seo';
+import {
+  buildPageMetadata,
+  isAppLocale,
+  localizedPath,
+  type AppLocale,
+} from '@/lib/seo';
+import { getSiteUrl } from '@/lib/site-url';
+import type { ArticleEntity } from '@/backend/article/domain/entities/ArticleEntity';
+import type { NewsArticle } from '@/src/features/news/types/article.types';
 
 interface Props {
   params: Promise<{ locale: string; id: string }>;
+}
+
+function toAbsoluteUrl(path: string): string {
+  return `${getSiteUrl()}${path}`;
+}
+
+/**
+ * 뉴스 기사용 NewsArticle 구조화 데이터(JSON-LD).
+ * 구글이 페이지를 "뉴스 기사"로 인식해 발행일·게시자·대표 이미지를 리치 결과로 노출하고
+ * 색인 우선순위를 높이도록 돕는다.
+ */
+function buildNewsArticleJsonLd(
+  entity: ArticleEntity,
+  article: NewsArticle,
+  locale: AppLocale,
+) {
+  const articleUrl = toAbsoluteUrl(
+    localizedPath(locale, `/news/article/${article.id}`),
+  );
+  const publishedAt = new Date(entity.created_at).toISOString();
+  const imageUrl = article.mainImage.src
+    ? new URL(article.mainImage.src, getSiteUrl()).toString()
+    : toAbsoluteUrl('/images/news-card-1.png');
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'NewsArticle',
+    headline: article.title.replace(/\n/g, ' ').trim(),
+    description: article.description,
+    image: [imageUrl],
+    datePublished: publishedAt,
+    dateModified: publishedAt,
+    inLanguage: locale,
+    mainEntityOfPage: { '@type': 'WebPage', '@id': articleUrl },
+    url: articleUrl,
+    author: { '@type': 'Organization', name: 'digitalPresso' },
+    publisher: {
+      '@type': 'Organization',
+      name: 'digitalPresso',
+      logo: {
+        '@type': 'ImageObject',
+        url: toAbsoluteUrl('/images/header-background.png'),
+      },
+    },
+  };
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
@@ -23,7 +76,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     return buildPageMetadata({
       locale: safeLocale,
       path: `/news/article/${id}`,
-      title: 'Article Not Found | digitalPresso',
+      title: 'Article Not Found',
       description: '요청한 뉴스 아티클을 찾을 수 없습니다.',
       noIndex: true,
     });
@@ -32,10 +85,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const article = mapCmsArticleToNewsArticle(entity, safeLocale);
   const cleanTitle = article.title.replace(/\n/g, ' ').trim();
 
+  // 제목의 ' | digitalPresso' 접미사는 layout.tsx의 title.template이 자동으로 붙임
   return buildPageMetadata({
     locale: safeLocale,
     path: `/news/article/${article.id}`,
-    title: `${cleanTitle} | digitalPresso`,
+    title: cleanTitle,
     description: article.description,
     image: article.mainImage.src || '/images/news-card-1.png',
   });
@@ -49,11 +103,17 @@ export default async function NewsArticlePage({ params }: Props) {
     notFound();
   }
 
+  const safeLocale: AppLocale = isAppLocale(locale) ? locale : 'ko';
   const article = mapCmsArticleToNewsArticle(entity, locale);
   const { prev, next } = await getAdjacentArticles(id);
+  const jsonLd = buildNewsArticleJsonLd(entity, article, safeLocale);
 
   return (
     <main>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       <NewsArticleDetail
         article={article}
         prevArticle={prev ? mapCmsArticleToNewsArticle(prev, locale) : undefined}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono, Noto_Sans_JP, Noto_Sans_KR } from "next/font/google";
 import localFont from "next/font/local";
-import GoogleAnalytics from "@/components/analytics/GoogleAnalytics";
-import GAPageTracker from "@/components/analytics/GAPageTracker";
 import { getSiteUrl } from "@/lib/site-url";
 import QueryProvider from "@/src/providers/QueryProvider";
 import "./globals.css";
@@ -91,8 +89,6 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} ${notoSansKR.variable} ${notoSansJP.variable} ${pretendard.variable}`}
       >
-        <GoogleAnalytics />
-        <GAPageTracker />
         <QueryProvider>{children}</QueryProvider>
       </body>
     </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10734,6 +10734,16 @@
         }
       }
     },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/no-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- `/admin` 경로에서 Google Analytics 추적 제외

- 뉴스 기사 페이지에 `NewsArticle` JSON-LD 추가

- 기사 페이지 제목의 중복 접미사 제거


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>layout.tsx</strong><dd><code>GA 추적 컴포넌트를 로케일 레이아웃으로 이동</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/[locale]/layout.tsx

<li><code>GoogleAnalytics</code> 및 <code>GAPageTracker</code> 컴포넌트를 추가했습니다.<br> <li> Google Analytics 스크립트가 <code>[locale]</code> 경로에서만 로드되도록 변경했습니다.


</details>


  </td>
  <td><a href="https://github.com/Digitalpresso-ai/digitalpresso-homepage/pull/64/files#diff-44ca66e460fac15e804a2ab56f6038ef2dd0a231881294f0a3895f9ad7624c58">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>뉴스 기사 페이지에 NewsArticle JSON-LD 추가 및 제목 형식 개선</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/[locale]/news/article/[id]/page.tsx

<li><code>NewsArticle</code> 스키마에 맞는 JSON-LD 구조화 데이터를 생성하는 <code>buildNewsArticleJsonLd</code> 함수를 <br>추가했습니다.<br> <li> 생성된 JSON-LD 스크립트를 페이지에 삽입하여 SEO를 강화했습니다.<br> <li> 기사 제목에서 ' | digitalPresso' 접미사를 제거하여 중복을 방지했습니다.<br> <li> 'Article Not Found' 페이지의 제목 형식도 간소화했습니다.


</details>


  </td>
  <td><a href="https://github.com/Digitalpresso-ai/digitalpresso-homepage/pull/64/files#diff-b69667d6eca34150b9f7c94b8883bc7a6c038cb45c6909c764f7ba9a6a792f3c">+63/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>layout.tsx</strong><dd><code>전역 GA 추적 컴포넌트 제거</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/layout.tsx

<li>전역 <code>GoogleAnalytics</code> 및 <code>GAPageTracker</code> 컴포넌트를 제거했습니다.<br> <li> Google Analytics 스크립트 로드가 <code>[locale]</code> 레이아웃으로 이전되었습니다.


</details>


  </td>
  <td><a href="https://github.com/Digitalpresso-ai/digitalpresso-homepage/pull/64/files#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030b">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>