### PR TITLE
feat(seo): vercel.app 호스트를 정식 도메인으로 301 리다이렉트

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -2,11 +2,25 @@ import createIntlMiddleware from 'next-intl/middleware';
 import { createServerClient } from '@supabase/ssr';
 import { NextResponse, type NextRequest } from 'next/server';
 import { routing } from '@/i18n/routing';
+import { getSiteUrl } from '@/lib/site-url';
 
 const intlMiddleware = createIntlMiddleware(routing);
 
+// 정식 도메인(예: digitalpresso.ai)의 호스트네임
+const CANONICAL_HOST = new URL(getSiteUrl()).host;
+
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
+
+  // 비정식 호스트(*.vercel.app 등)로 들어온 요청은 정식 도메인으로 301 영구 이동.
+  // 과거에 색인된 vercel.app URL을 정식 도메인으로 통합하고 404 노출을 막는다.
+  const host = request.headers.get('host') ?? '';
+  if (host && host !== CANONICAL_HOST && host.endsWith('.vercel.app')) {
+    const target = new URL(getSiteUrl());
+    target.pathname = request.nextUrl.pathname;
+    target.search = request.nextUrl.search;
+    return NextResponse.redirect(target, 301);
+  }
 
   // Admin 경로 인증 처리
   if (pathname.startsWith('/admin')) {


### PR DESCRIPTION
과거에 색인된 *.vercel.app URL이 검색에 남아 클릭 시 404(DEPLOYMENT_NOT_FOUND)가 노출되는 문제 해결. 비정식 호스트(*.vercel.app)로 들어온 요청을 경로·쿼리를 보존한 채 digitalpresso.ai로 301 영구 이동시켜, 과거 색인 평판을 정식 도메인으로 통합하고 구글이 vercel.app URL을 검색에서 제거하도록 유도한다. 정식 도메인 요청에는 영향 없음.