### PR TITLE
fix(admin): 게시하기 전 자동 저장 + API 에러 메시지 노출

### DIFF
--- a/src/features/admin/components/ArticleEditor/ArticleEditor.tsx
+++ b/src/features/admin/components/ArticleEditor/ArticleEditor.tsx
@@ -247,67 +247,76 @@ export default function ArticleEditor({ article }: Props) {
   };
 
   const handlePublishToggle = () => {
-    const targetId = currentArticleId ?? article?.id;
-    if (!targetId) {
-      setPublishError('먼저 저장한 뒤 게시할 수 있습니다.');
+    // 게시 내리기(unpublish)는 저장 없이 바로 처리
+    if (isPublished) {
+      const targetId = currentArticleId ?? article?.id;
+      if (!targetId) { setPublishError('대상 아티클이 없습니다.'); return; }
+      const ok = window.confirm('이 아티클을 사이트에서 내려 임시저장으로 되돌릴까요?');
+      if (!ok) return;
+      setPublishError(null);
+      startTransition(async () => {
+        try {
+          const updated = await publishArticleMutation.mutateAsync({ id: targetId, unpublish: true });
+          setStatus(updated.status);
+        } catch (error) {
+          setPublishError(error instanceof Error ? error.message : '게시 처리에 실패했습니다.');
+        }
+      });
       return;
     }
 
-    if (isPublished) {
-      const ok = window.confirm('이 아티클을 사이트에서 내려 임시저장으로 되돌릴까요?');
-      if (!ok) return;
-    }
-
-    setPublishError(null);
-    startTransition(async () => {
-      try {
-        const updated = await publishArticleMutation.mutateAsync({
-          id: targetId,
-          unpublish: isPublished,
-        });
-        setStatus(updated.status);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : '게시 처리에 실패했습니다.';
-        setPublishError(message);
-      }
-    });
-  };
-
-  const handleSubmit = () => {
+    // 게시: 먼저 현재 편집 내용(대표 이미지 포함)을 저장한 뒤 게시한다.
+    // 이렇게 해야 새로 고른 이미지가 DB 의 cover_img_url 에 반영돼 게시 검증을 통과한다.
     const content = editor?.getHTML() ?? '';
     if (!title.trim()) { setServerError('제목을 입력해주세요.'); return; }
     if (!content || content === '<p></p>') { setServerError('본문을 작성해주세요.'); return; }
 
     setServerError(null);
-    setSaveSuccess(false);
-
+    setPublishError(null);
     startTransition(async () => {
-      let createdArticleId: string | null = null;
       try {
-        setIsUploading(true);
-        setUploadError(null);
+        const saved = await saveArticle();
+        const updated = await publishArticleMutation.mutateAsync({ id: saved.articleId, unpublish: false });
+        setStatus(updated.status);
+      } catch (error) {
+        setPublishError(error instanceof Error ? error.message : '게시 처리에 실패했습니다.');
+      }
+    });
+  };
 
-        const supabase = createBrowserClient();
-        let articleId = article?.id;
+  /**
+   * 현재 편집 내용을 저장한다(생성/이미지 업로드/업데이트 일괄).
+   * 저장된 articleId 와 cover URL 을 반환한다. 저장과 게시 양쪽에서 재사용.
+   */
+  const saveArticle = async (): Promise<{ articleId: string; coverUrl: string | null }> => {
+    const content = editor?.getHTML() ?? '';
+    setSaveSuccess(false);
+    let createdArticleId: string | null = null;
+    try {
+      setIsUploading(true);
+      setUploadError(null);
 
-        if (!articleId) {
-          const created = await createArticleMutation.mutateAsync({
-            title,
-            category,
-            title_en: '',
-            title_ja: '',
-            content: '',
-            content_en: '',
-            content_ja: '',
-            cover_img_url: null,
-          });
-          articleId = created.id;
-          createdArticleId = created.id;
-          setCurrentArticleId(created.id);
-        }
+      const supabase = createBrowserClient();
+      let articleId = currentArticleId ?? article?.id;
 
-        let nextContent = content;
-        let resolvedCoverUrl: string | null = coverImageUrl;
+      if (!articleId) {
+        const created = await createArticleMutation.mutateAsync({
+          title,
+          category,
+          title_en: '',
+          title_ja: '',
+          content: '',
+          content_en: '',
+          content_ja: '',
+          cover_img_url: null,
+        });
+        articleId = created.id;
+        createdArticleId = created.id;
+        setCurrentArticleId(created.id);
+      }
+
+      let nextContent = content;
+      let resolvedCoverUrl: string | null = coverImageUrl;
 
         if (pendingCoverFile) {
           const objectKey = generateId();
@@ -411,30 +420,48 @@ export default function ArticleEditor({ article }: Props) {
           },
         });
 
-        if (editor && nextContent !== content) {
-          editor.commands.setContent(nextContent);
-        }
+      if (editor && nextContent !== content) {
+        editor.commands.setContent(nextContent);
+      }
 
-        setPendingImages({});
-        if (pendingCoverPreview) URL.revokeObjectURL(pendingCoverPreview);
-        setPendingCoverFile(null);
-        setPendingCoverPreview(null);
-        setCoverImageUrl(resolvedCoverUrl);
-        setSaveSuccess(true);
-        setTimeout(() => setSaveSuccess(false), 3000);
+      setPendingImages({});
+      if (pendingCoverPreview) URL.revokeObjectURL(pendingCoverPreview);
+      setPendingCoverFile(null);
+      setPendingCoverPreview(null);
+      setCoverImageUrl(resolvedCoverUrl);
+      setSaveSuccess(true);
+      setTimeout(() => setSaveSuccess(false), 3000);
 
-        if (!isEdit && createdArticleId) {
-          router.replace(`/admin/articles/${createdArticleId}/edit`);
-        }
-      } catch (error) {
-        const message = error instanceof Error ? error.message : '저장에 실패했습니다.';
-        setUploadError(message);
+      if (!isEdit && createdArticleId) {
+        router.replace(`/admin/articles/${createdArticleId}/edit`);
+      }
 
-        if (!isEdit && createdArticleId) {
-          await fetch(`/api/articles/${createdArticleId}`, { method: 'DELETE' });
-        }
-      } finally {
-        setIsUploading(false);
+      return { articleId, coverUrl: resolvedCoverUrl };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : '저장에 실패했습니다.';
+      setUploadError(message);
+
+      if (!isEdit && createdArticleId) {
+        await fetch(`/api/articles/${createdArticleId}`, { method: 'DELETE' });
+        setCurrentArticleId(null);
+      }
+      throw error instanceof Error ? error : new Error(message);
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const handleSubmit = () => {
+    const content = editor?.getHTML() ?? '';
+    if (!title.trim()) { setServerError('제목을 입력해주세요.'); return; }
+    if (!content || content === '<p></p>') { setServerError('본문을 작성해주세요.'); return; }
+
+    setServerError(null);
+    startTransition(async () => {
+      try {
+        await saveArticle();
+      } catch {
+        // 에러는 saveArticle 내부에서 uploadError 로 표시됨
       }
     });
   };

--- a/src/lib/api/articles.api.ts
+++ b/src/lib/api/articles.api.ts
@@ -4,6 +4,17 @@ import type { ApiResponse } from '@/backend/shared/types/ApiResponse';
 
 const api = axios.create({ baseURL: '/api' });
 
+// 서버가 4xx/5xx 를 주면 axios 가 "Request failed with status code 400" 같은
+// 기본 메시지로 throw 한다. 응답 body 의 한국어 error 메시지를 대신 노출한다.
+api.interceptors.response.use(
+  (res) => res,
+  (error) => {
+    const serverMsg = error?.response?.data?.error;
+    if (serverMsg) return Promise.reject(new Error(serverMsg));
+    return Promise.reject(error);
+  }
+);
+
 export interface GetArticlesParams {
   category?: string;
   limit?: number;


### PR DESCRIPTION
### **User description**
- [게시하기]가 먼저 현재 편집 내용(대표 이미지 포함)을 저장한 뒤 게시하도록 변경. 이전에는 새로 고른 대표 이미지가 DB에 반영되기 전 게시를 시도해 "대표 이미지가 없어 게시할 수 없습니다" 400 에러가 발생했음.
- axios 응답 인터셉터로 서버의 한국어 error 메시지를 노출. (이전엔 "Request failed with status code 400" 만 보였음)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- 게시 전 자동 저장으로 대표 이미지 오류 해결.

- 서버 API 에러 메시지 사용자에게 노출.

- 아티클 저장 로직 재사용 함수로 분리.

- 게시/저장 전 제목, 본문 유효성 검사.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ArticleEditor.tsx</strong><dd><code>아티클 게시 및 저장 로직 개선</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/features/admin/components/ArticleEditor/ArticleEditor.tsx

<li>게시(Publish) 로직을 수정하여, 게시하기 전에 현재 편집 내용(대표 이미지 포함)을 먼저 저장하도록 변경했습니다.<br> <li> 아티클 생성, 이미지 업로드, 업데이트 등 현재 편집 내용을 저장하는 로직을 <code>saveArticle</code>이라는 재사용 가능한 비동기 <br>함수로 분리했습니다.<br> <li> 게시 내리기(Unpublish)는 저장 과정 없이 즉시 처리되도록 분리했습니다.<br> <li> 게시 및 저장 전에 제목과 본문 내용의 유효성을 검사하는 로직을 추가했습니다.


</details>


  </td>
  <td><a href="https://github.com/Digitalpresso-ai/digitalpresso-homepage/pull/73/files#diff-14552e405f6a60de3b34ffc950a9120e92167686d153d6882afee04b0d5f2af9">+92/-65</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>articles.api.ts</strong><dd><code>Axios 응답 인터셉터로 서버 에러 메시지 노출</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/api/articles.api.ts

<li>Axios 응답 인터셉터를 추가하여 서버에서 반환하는 한국어 에러 메시지를 추출하도록 했습니다.<br> <li> 4xx/5xx 응답 시, 서버의 <code>error?.response?.data?.error</code> 메시지가 있다면 이를 사용하여 에러를 <br>발생시킵니다.


</details>


  </td>
  <td><a href="https://github.com/Digitalpresso-ai/digitalpresso-homepage/pull/73/files#diff-0f7b0dbe99c9f218880b6cc9a835aeda9dc6260704e873a1f135e7dfc3039e08">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>