### PR TITLE
Develop

### DIFF
--- a/src/features/admin/components/ArticleEditor/ArticleEditor.tsx
+++ b/src/features/admin/components/ArticleEditor/ArticleEditor.tsx
@@ -247,67 +247,76 @@ export default function ArticleEditor({ article }: Props) {
   };
 
   const handlePublishToggle = () => {
-    const targetId = currentArticleId ?? article?.id;
-    if (!targetId) {
-      setPublishError('먼저 저장한 뒤 게시할 수 있습니다.');
+    // 게시 내리기(unpublish)는 저장 없이 바로 처리
+    if (isPublished) {
+      const targetId = currentArticleId ?? article?.id;
+      if (!targetId) { setPublishError('대상 아티클이 없습니다.'); return; }
+      const ok = window.confirm('이 아티클을 사이트에서 내려 임시저장으로 되돌릴까요?');
+      if (!ok) return;
+      setPublishError(null);
+      startTransition(async () => {
+        try {
+          const updated = await publishArticleMutation.mutateAsync({ id: targetId, unpublish: true });
+          setStatus(updated.status);
+        } catch (error) {
+          setPublishError(error instanceof Error ? error.message : '게시 처리에 실패했습니다.');
+        }
+      });
       return;
     }
 
-    if (isPublished) {
-      const ok = window.confirm('이 아티클을 사이트에서 내려 임시저장으로 되돌릴까요?');
-      if (!ok) return;
-    }
-
-    setPublishError(null);
-    startTransition(async () => {
-      try {
-        const updated = await publishArticleMutation.mutateAsync({
-          id: targetId,
-          unpublish: isPublished,
-        });
-        setStatus(updated.status);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : '게시 처리에 실패했습니다.';
-        setPublishError(message);
-      }
-    });
-  };
-
-  const handleSubmit = () => {
+    // 게시: 먼저 현재 편집 내용(대표 이미지 포함)을 저장한 뒤 게시한다.
+    // 이렇게 해야 새로 고른 이미지가 DB 의 cover_img_url 에 반영돼 게시 검증을 통과한다.
     const content = editor?.getHTML() ?? '';
     if (!title.trim()) { setServerError('제목을 입력해주세요.'); return; }
     if (!content || content === '<p></p>') { setServerError('본문을 작성해주세요.'); return; }
 
     setServerError(null);
-    setSaveSuccess(false);
-
+    setPublishError(null);
     startTransition(async () => {
-      let createdArticleId: string | null = null;
       try {
-        setIsUploading(true);
-        setUploadError(null);
+        const saved = await saveArticle();
+        const updated = await publishArticleMutation.mutateAsync({ id: saved.articleId, unpublish: false });
+        setStatus(updated.status);
+      } catch (error) {
+        setPublishError(error instanceof Error ? error.message : '게시 처리에 실패했습니다.');
+      }
+    });
+  };
 
-        const supabase = createBrowserClient();
-        let articleId = article?.id;
+  /**
+   * 현재 편집 내용을 저장한다(생성/이미지 업로드/업데이트 일괄).
+   * 저장된 articleId 와 cover URL 을 반환한다. 저장과 게시 양쪽에서 재사용.
+   */
+  const saveArticle = async (): Promise<{ articleId: string; coverUrl: string | null }> => {
+    const content = editor?.getHTML() ?? '';
+    setSaveSuccess(false);
+    let createdArticleId: string | null = null;
+    try {
+      setIsUploading(true);
+      setUploadError(null);
 
-        if (!articleId) {
-          const created = await createArticleMutation.mutateAsync({
-            title,
-            category,
-            title_en: '',
-            title_ja: '',
-            content: '',
-            content_en: '',
-            content_ja: '',
-            cover_img_url: null,
-          });
-          articleId = created.id;
-          createdArticleId = created.id;
-          setCurrentArticleId(created.id);
-        }
+      const supabase = createBrowserClient();
+      let articleId = currentArticleId ?? article?.id;
 
-        let nextContent = content;
-        let resolvedCoverUrl: string | null = coverImageUrl;
+      if (!articleId) {
+        const created = await createArticleMutation.mutateAsync({
+          title,
+          category,
+          title_en: '',
+          title_ja: '',
+          content: '',
+          content_en: '',
+          content_ja: '',
+          cover_img_url: null,
+        });
+        articleId = created.id;
+        createdArticleId = created.id;
+        setCurrentArticleId(created.id);
+      }
+
+      let nextContent = content;
+      let resolvedCoverUrl: string | null = coverImageUrl;
 
         if (pendingCoverFile) {
           const objectKey = generateId();
@@ -411,30 +420,48 @@ export default function ArticleEditor({ article }: Props) {
           },
         });
 
-        if (editor && nextContent !== content) {
-          editor.commands.setContent(nextContent);
-        }
+      if (editor && nextContent !== content) {
+        editor.commands.setContent(nextContent);
+      }
 
-        setPendingImages({});
-        if (pendingCoverPreview) URL.revokeObjectURL(pendingCoverPreview);
-        setPendingCoverFile(null);
-        setPendingCoverPreview(null);
-        setCoverImageUrl(resolvedCoverUrl);
-        setSaveSuccess(true);
-        setTimeout(() => setSaveSuccess(false), 3000);
+      setPendingImages({});
+      if (pendingCoverPreview) URL.revokeObjectURL(pendingCoverPreview);
+      setPendingCoverFile(null);
+      setPendingCoverPreview(null);
+      setCoverImageUrl(resolvedCoverUrl);
+      setSaveSuccess(true);
+      setTimeout(() => setSaveSuccess(false), 3000);
 
-        if (!isEdit && createdArticleId) {
-          router.replace(`/admin/articles/${createdArticleId}/edit`);
-        }
-      } catch (error) {
-        const message = error instanceof Error ? error.message : '저장에 실패했습니다.';
-        setUploadError(message);
+      if (!isEdit && createdArticleId) {
+        router.replace(`/admin/articles/${createdArticleId}/edit`);
+      }
 
-        if (!isEdit && createdArticleId) {
-          await fetch(`/api/articles/${createdArticleId}`, { method: 'DELETE' });
-        }
-      } finally {
-        setIsUploading(false);
+      return { articleId, coverUrl: resolvedCoverUrl };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : '저장에 실패했습니다.';
+      setUploadError(message);
+
+      if (!isEdit && createdArticleId) {
+        await fetch(`/api/articles/${createdArticleId}`, { method: 'DELETE' });
+        setCurrentArticleId(null);
+      }
+      throw error instanceof Error ? error : new Error(message);
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const handleSubmit = () => {
+    const content = editor?.getHTML() ?? '';
+    if (!title.trim()) { setServerError('제목을 입력해주세요.'); return; }
+    if (!content || content === '<p></p>') { setServerError('본문을 작성해주세요.'); return; }
+
+    setServerError(null);
+    startTransition(async () => {
+      try {
+        await saveArticle();
+      } catch {
+        // 에러는 saveArticle 내부에서 uploadError 로 표시됨
       }
     });
   };

--- a/src/lib/api/articles.api.ts
+++ b/src/lib/api/articles.api.ts
@@ -4,6 +4,17 @@ import type { ApiResponse } from '@/backend/shared/types/ApiResponse';
 
 const api = axios.create({ baseURL: '/api' });
 
+// 서버가 4xx/5xx 를 주면 axios 가 "Request failed with status code 400" 같은
+// 기본 메시지로 throw 한다. 응답 body 의 한국어 error 메시지를 대신 노출한다.
+api.interceptors.response.use(
+  (res) => res,
+  (error) => {
+    const serverMsg = error?.response?.data?.error;
+    if (serverMsg) return Promise.reject(new Error(serverMsg));
+    return Promise.reject(error);
+  }
+);
+
 export interface GetArticlesParams {
   category?: string;
   limit?: number;


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- 게시 전 현재 편집 내용(대표 이미지 포함) 자동 저장

- 게시 취소 로직을 저장 없이 즉시 처리하도록 분리

- API 응답 인터셉터를 통해 서버의 상세 에러 메시지 노출

- 아티클 저장 로직을 재사용 가능한 함수로 분리


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ArticleEditor.tsx</strong><dd><code>게시 전 자동 저장 및 아티클 저장 로직 분리</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/features/admin/components/ArticleEditor/ArticleEditor.tsx

<li><code>handlePublishToggle</code> 함수가 게시하기 전에 <code>saveArticle</code> 함수를 호출하여 현재 편집 내용(특히 대표 <br>이미지)을 먼저 저장하도록 변경되었습니다. 이는 새로 선택한 대표 이미지가 DB에 반영되지 않아 발생하던 게시 오류를 <br>해결합니다.<br> <li> 게시 취소(unpublish) 로직이 저장 과정 없이 즉시 처리되도록 분리되었습니다.<br> <li> 아티클 생성, 이미지 업로드, 내용 업데이트를 포함하는 저장 로직이 <code>saveArticle</code>이라는 새로운 비동기 함수로 추출되어 <br><code>handleSubmit</code> 및 <code>handlePublishToggle</code>에서 재사용됩니다.<br> <li> <code>saveArticle</code> 함수 내에서 새로운 아티클 생성 실패 시 <code>currentArticleId</code>를 <code>null</code>로 재설정하는 로직이 <br>추가되었습니다.


</details>


  </td>
  <td><a href="https://github.com/Digitalpresso-ai/digitalpresso-homepage/pull/74/files#diff-14552e405f6a60de3b34ffc950a9120e92167686d153d6882afee04b0d5f2af9">+92/-65</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>articles.api.ts</strong><dd><code>Axios 응답 인터셉터로 API 에러 메시지 개선</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/api/articles.api.ts

<li>Axios 응답 인터셉터가 추가되어 서버에서 4xx/5xx 오류 응답 시 응답 본문의 한국어 에러 <br>메시지(<code>error?.response?.data?.error</code>)를 추출하여 사용자에게 표시합니다.<br> <li> 이를 통해 "Request failed with status code 400"과 같은 일반적인 Axios 오류 메시지 대신 더 <br>구체적이고 유용한 서버 메시지가 노출됩니다.


</details>


  </td>
  <td><a href="https://github.com/Digitalpresso-ai/digitalpresso-homepage/pull/74/files#diff-0f7b0dbe99c9f218880b6cc9a835aeda9dc6260704e873a1f135e7dfc3039e08">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>