### PR TITLE
Feature/redesign ch

### DIFF
--- a/app/api/articles/[id]/publish/route.ts
+++ b/app/api/articles/[id]/publish/route.ts
@@ -6,6 +6,7 @@ import {
   unpublishArticle,
   getArticleById,
 } from '@/backend/article/application/server-facade';
+import { hasUnresolvedImages } from '@/backend/article/application/sanitizeArticleImages';
 import type { ApiResponse } from '@/backend/shared/types/ApiResponse';
 
 interface Params {
@@ -42,6 +43,18 @@ export async function POST(req: NextRequest, { params }: Params) {
       }
       if (!existing.cover_img_url?.trim()) {
         return NextResponse.json<ApiResponse<never>>({ success: false, error: '대표 이미지가 없어 게시할 수 없습니다.' }, { status: 400 });
+      }
+      // 본문에 접속 불가능한(깨질) 이미지가 남아있으면 게시 차단.
+      // MCP로 올라온 상대경로 이미지가 실서버에 그대로 노출되는 것을 원천 차단한다.
+      if (
+        hasUnresolvedImages(existing.content ?? '') ||
+        hasUnresolvedImages(existing.content_en ?? '') ||
+        hasUnresolvedImages(existing.content_ja ?? '')
+      ) {
+        return NextResponse.json<ApiResponse<never>>(
+          { success: false, error: '본문에 업로드되지 않은 이미지가 있어 게시할 수 없습니다. 에디터에서 해당 이미지를 직접 업로드해주세요.' },
+          { status: 400 },
+        );
       }
     }
 

--- a/backend/article/application/sanitizeArticleImages.ts
+++ b/backend/article/application/sanitizeArticleImages.ts
@@ -1,0 +1,74 @@
+// 아티클 본문 HTML의 이미지 src를 검증한다.
+//
+// MCP/스킬로 올라온 글은 이미지 "바이너리"가 서버에 전송되지 않는다(텍스트만 전송).
+// 그래서 마크다운 `![](article9-main.png)` 같은 참조는 `<img src="article9-main.png">`
+// 처럼 실제로 접속 불가능한 상대경로로 남는다. 이 상태로 게시되면 실서버에서 이미지가
+// 깨져(alt 텍스트만 노출) 보인다.
+//
+// 여기서는 "해결 가능한(resolvable) 이미지"만 통과시킨다. 그 외는 눈에 띄는 플레이스홀더로
+// 치환해, admin 에디터에서 어느 위치에 어떤 이미지를 넣어야 하는지 알 수 있게 한다.
+
+// http(s) 절대 URL, 프로토콜 상대(//...), data: URI, 그리고 /public 기준 절대경로(/...)는
+// 렌더 시 실제로 접속 가능하므로 유효한 것으로 본다.
+function isResolvableSrc(src: string): boolean {
+  const s = src.trim();
+  if (!s) return false;
+  return (
+    /^https?:\/\//i.test(s) ||
+    s.startsWith('//') ||
+    s.startsWith('data:') ||
+    s.startsWith('/')
+  );
+}
+
+function extractSrc(attrs: string): string | null {
+  const match = attrs.match(/\ssrc\s*=\s*("([^"]*)"|'([^']*)')/i);
+  if (!match) return null;
+  return match[2] ?? match[3] ?? '';
+}
+
+export interface SanitizeArticleImagesResult {
+  /** 미해결 이미지를 플레이스홀더로 치환한 HTML */
+  html: string;
+  /** 제거(치환)된 이미지의 원본 src 목록 */
+  removed: string[];
+}
+
+/**
+ * 본문 HTML에서 접속 불가능한 `<img>`를 찾아 플레이스홀더로 치환한다.
+ * admin 에디터가 인식할 수 있도록 `data-missing-image` 속성과 원본 파일명을 남긴다.
+ */
+export function sanitizeArticleImages(html: string): SanitizeArticleImagesResult {
+  const removed: string[] = [];
+
+  const out = html.replace(/<img\b([^>]*)>/gi, (match, attrs: string) => {
+    const src = extractSrc(attrs);
+    // src가 없거나(빈 img) 접속 불가능한 경우 → 플레이스홀더
+    if (src !== null && isResolvableSrc(src)) return match;
+
+    const label = (src ?? '').trim() || '이미지';
+    removed.push(label);
+    const safeLabel = label
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+
+    return `<p data-missing-image="${safeLabel}"><em>[이미지 자리: ${safeLabel} — admin에서 직접 업로드하세요]</em></p>`;
+  });
+
+  return { html: out, removed };
+}
+
+/**
+ * 본문 HTML에 아직 미해결(접속 불가능한) 이미지가 남아있는지 검사한다.
+ * 게시 차단 검증에서 사용한다.
+ */
+export function hasUnresolvedImages(html: string): boolean {
+  const matches = html.match(/<img\b[^>]*>/gi);
+  if (!matches) return false;
+  return matches.some((tag) => {
+    const src = extractSrc(tag);
+    return src === null || !isResolvableSrc(src);
+  });
+}

--- a/backend/article/application/usecases/UploadDraftUsecase.ts
+++ b/backend/article/application/usecases/UploadDraftUsecase.ts
@@ -1,5 +1,6 @@
 import { marked } from 'marked';
 import type { IArticleRepository } from '../../domain/repositories/IArticleRepository';
+import { sanitizeArticleImages } from '../sanitizeArticleImages';
 
 export interface UploadDraftInput {
   title: string;
@@ -15,7 +16,7 @@ export interface UploadDraftInput {
 }
 
 export type UploadDraftResult =
-  | { success: true; id: string; deduplicated: boolean }
+  | { success: true; id: string; deduplicated: boolean; removedImages: string[] }
   | { success: false; error: string };
 
 function normalizeCategory(category?: string): 'company' | 'construction' | 'technology' {
@@ -49,14 +50,27 @@ export class UploadDraftUsecase {
     if (marker) {
       const duplicate = await this.repo.findByContentPattern(`%${marker}%`);
       if (duplicate) {
-        return { success: true, id: duplicate.id, deduplicated: true };
+        return { success: true, id: duplicate.id, deduplicated: true, removedImages: [] };
       }
     }
 
     const fmt = input.contentFormat ?? 'markdown';
-    const content = toHtml(rawContent, fmt);
-    const contentEn = input.contentEn ? toHtml(input.contentEn, fmt) : '';
-    const contentJa = input.contentJa ? toHtml(input.contentJa, fmt) : '';
+
+    // MCP/스킬 업로드는 이미지 바이너리가 전송되지 않으므로, 마크다운의 상대경로 이미지
+    // (예: article9-main.png)는 실서버에서 접속 불가능해 깨진다. 저장 전에 걸러내고,
+    // admin 에디터가 인식할 수 있는 플레이스홀더로 치환한다.
+    const ko = sanitizeArticleImages(toHtml(rawContent, fmt));
+    const en = input.contentEn ? sanitizeArticleImages(toHtml(input.contentEn, fmt)) : null;
+    const ja = input.contentJa ? sanitizeArticleImages(toHtml(input.contentJa, fmt)) : null;
+
+    const content = ko.html;
+    const contentEn = en?.html ?? '';
+    const contentJa = ja?.html ?? '';
+    const removedImages = [
+      ...ko.removed,
+      ...(en?.removed ?? []),
+      ...(ja?.removed ?? []),
+    ];
 
     // MCP/스킬로 올라온 글은 항상 임시저장(draft)으로 들어간다.
     // 대표 이미지를 넣고 admin 에서 [게시] 를 눌러야 실서버에 공개된다.
@@ -73,6 +87,6 @@ export class UploadDraftUsecase {
       published_at: null,
     });
 
-    return { success: true, id: article.id, deduplicated: false };
+    return { success: true, id: article.id, deduplicated: false, removedImages };
   }
 }

--- a/src/features/news/components/NewsArticleDetail/NewsArticleDetail.module.css
+++ b/src/features/news/components/NewsArticleDetail/NewsArticleDetail.module.css
@@ -224,10 +224,11 @@
   margin-bottom: 0;
 }
 
+/* PC/태블릿: 문단 폭의 70% */
 .htmlContent img {
-  max-width: 70% !important;
-  width: auto !important;
-  height: auto !important;
+  max-width: 70%;
+  width: auto;
+  height: auto;
   display: block;
   margin: 0 0 24px;
 }
@@ -323,5 +324,11 @@
 
   .htmlContent p {
     margin-bottom: 16px;
+  }
+
+  /* 모바일: 본문 이미지를 문단 폭에 꽉 차게 */
+  .htmlContent img {
+    max-width: 100%;
+    width: 100%;
   }
 }

--- a/src/features/news/components/NewsArticleDetail/NewsArticleDetail.tsx
+++ b/src/features/news/components/NewsArticleDetail/NewsArticleDetail.tsx
@@ -9,12 +9,14 @@ import type { NewsArticle } from '../../types/article.types';
 import styles from './NewsArticleDetail.module.css';
 
 function sanitizeHtmlImages(html: string): string {
+  // 인라인 style/width/height 를 제거해 크기 제어를 CSS(.htmlContent img)에 위임한다.
+  // 인라인 스타일을 남기면 반응형 미디어쿼리가 먹지 않으므로, 폭은 CSS에서만 다룬다.
   return html.replace(/<img([^>]*)>/gi, (_match, attrs: string) => {
     const cleaned = attrs
       .replace(/\s*style="[^"]*"/gi, '')
       .replace(/\s*width="[^"]*"/gi, '')
       .replace(/\s*height="[^"]*"/gi, '');
-    return `<img${cleaned} style="max-width:70%;height:auto;display:block;margin:0 0 24px">`;
+    return `<img${cleaned}>`;
   });
 }
 

--- a/src/mcp/create-server.ts
+++ b/src/mcp/create-server.ts
@@ -273,9 +273,14 @@ ${action}
         }
       }
 
+      const imageWarning =
+        result.removedImages.length > 0
+          ? `\n\n⚠️ 접속 불가능한 이미지 ${result.removedImages.length}개(${result.removedImages.join(', ')})를 본문에서 제거하고 자리 표시만 남겼습니다. MCP로는 이미지 파일이 전송되지 않으므로, admin 에디터에서 해당 위치에 실제 이미지를 직접 업로드해야 합니다.`
+          : ''
+
       const message = result.deduplicated
         ? `이미 같은 sourceUrl로 임시저장된 초안이 있어 기존 항목을 반환합니다. id=${result.id}`
-        : `초안을 임시저장(draft)했습니다. id=${result.id}\n아직 실서버에 공개되지 않았습니다. admin 아티클 관리에서 대표 이미지를 넣고 [게시] 버튼을 눌러야 공개됩니다.`
+        : `초안을 임시저장(draft)했습니다. id=${result.id}\n아직 실서버에 공개되지 않았습니다. admin 아티클 관리에서 대표 이미지를 넣고 [게시] 버튼을 눌러야 공개됩니다.${imageWarning}`
 
       return {
         content: [{
@@ -354,12 +359,17 @@ ${action}
         }
       }
 
+      const autoImageWarning =
+        result.removedImages.length > 0
+          ? `\n⚠️ 접속 불가능한 이미지 ${result.removedImages.length}개를 제거했습니다. admin 에디터에서 직접 업로드하세요.`
+          : ''
+
       return {
         content: [{
           type: 'text' as const,
           text: result.deduplicated
             ? `기존 초안을 재사용했습니다. id=${result.id}`
-            : `초안 자동 업로드 완료. id=${result.id}`,
+            : `초안 자동 업로드 완료. id=${result.id}${autoImageWarning}`,
         }],
       }
     }


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- MCP/스킬 업로드 시 깨진 이미지를 제거하고 게시를 차단합니다.

- 본문 HTML에서 접속 불가능한 이미지를 플레이스홀더로 치환합니다.

- 모바일에서 본문 이미지가 문단 폭 100%로 표시되도록 개선합니다.

- MCP 업로드 결과에 제거된 이미지 경고 메시지를 추가합니다.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>게시 전 미해결 이미지 본문 검증 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/api/articles/[id]/publish/route.ts

<li><code>hasUnresolvedImages</code> 함수를 임포트했습니다.<br> <li> 게시 API에서 한국어, 영어, 일본어 본문에 미해결 이미지가 있는지 확인하는 로직을 추가했습니다.<br> <li> 미해결 이미지가 발견되면 400 에러와 함께 게시를 차단합니다.


</details>


  </td>
  <td><a href="https://github.com/Digitalpresso-ai/digitalpresso-homepage/pull/75/files#diff-807a6397738726543a00fb78c321d4d1db8769ca4f4c29b0c88912b3fb56f029">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>New feature</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sanitizeArticleImages.ts</strong><dd><code>아티클 이미지 유효성 검증 및 치환 로직 구현</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/article/application/sanitizeArticleImages.ts

<li>이미지 <code>src</code>가 유효한지 확인하는 <code>isResolvableSrc</code> 함수를 정의했습니다.<br> <li> 본문 HTML에서 접속 불가능한 <code><img></code> 태그를 찾아 플레이스홀더로 치환하는 <code>sanitizeArticleImages</code> 함수를 <br>추가했습니다.<br> <li> 게시 차단 검증에 사용될 <code>hasUnresolvedImages</code> 함수를 구현했습니다.


</details>


  </td>
  <td><a href="https://github.com/Digitalpresso-ai/digitalpresso-homepage/pull/75/files#diff-1321a13cd3e71110d0e223a488d5dc397141e801a3fd93fa07a855b584f6fd9e">+74/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Data processing</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UploadDraftUsecase.ts</strong><dd><code>초안 업로드 시 이미지 자동 치환 및 경고 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/article/application/usecases/UploadDraftUsecase.ts

<li><code>sanitizeArticleImages</code> 함수를 임포트했습니다.<br> <li> 초안 업로드 시 한국어, 영어, 일본어 본문의 이미지를 <code>sanitizeArticleImages</code>로 처리하도록 변경했습니다.<br> <li> 치환된 이미지 목록(<code>removedImages</code>)을 업로드 결과에 포함하도록 <code>UploadDraftResult</code> 타입을 <br>업데이트했습니다.


</details>


  </td>
  <td><a href="https://github.com/Digitalpresso-ai/digitalpresso-homepage/pull/75/files#diff-020e69f5c69dd431b4b9bef095a3b1273f334c181945ad57e3ca6c5d2b0bf550">+20/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Styling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NewsArticleDetail.tsx</strong><dd><code>본문 이미지 인라인 스타일 제거 및 CSS 위임</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/features/news/components/NewsArticleDetail/NewsArticleDetail.tsx

<li><code>sanitizeHtmlImages</code> 함수에서 <code><img></code> 태그의 인라인 <code>style</code>, <code>width</code>, <code>height</code> 속성을 제거하도록 <br>변경했습니다.<br> <li> 이미지 크기 제어를 CSS로 완전히 위임하여 반응형 디자인을 가능하게 했습니다.


</details>


  </td>
  <td><a href="https://github.com/Digitalpresso-ai/digitalpresso-homepage/pull/75/files#diff-94b355ecc4e402c6cbf6675326c3c083ca633c35029d18b482e758fc76a56b25">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>User feedback</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create-server.ts</strong><dd><code>MCP 업로드 결과에 이미지 제거 경고 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/mcp/create-server.ts

<li>초안 업로드 결과에서 제거된 이미지 목록(<code>removedImages</code>)을 확인합니다.<br> <li> 제거된 이미지가 있을 경우, MCP 응답 메시지에 경고 문구를 추가하여 사용자에게 알립니다.<br> <li> 자동 업로드 시에도 동일한 경고 메시지를 추가했습니다.


</details>


  </td>
  <td><a href="https://github.com/Digitalpresso-ai/digitalpresso-homepage/pull/75/files#diff-1d5d96a5a5d6d277aa6ae266c08a4e226e15cfd645920739e510b119238bc853">+12/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Responsive design</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NewsArticleDetail.module.css</strong><dd><code>모바일 반응형 본문 이미지 스타일 적용</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/features/news/components/NewsArticleDetail/NewsArticleDetail.module.css

<li>PC/태블릿 환경에서 본문 이미지의 <code>max-width</code>를 70%로 유지하도록 CSS를 업데이트했습니다.<br> <li> 모바일(799px 이하) 환경에서 본문 이미지가 <code>max-width: 100%; width: 100%;</code>로 표시되도록 미디어 <br>쿼리를 추가했습니다.


</details>


  </td>
  <td><a href="https://github.com/Digitalpresso-ai/digitalpresso-homepage/pull/75/files#diff-2a634536c40c90373175408c74e653f71c2a80144933eb4a10dbbec7aed66c56">+10/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>