### PR TITLE
Develop

### DIFF
--- a/backend/shared/db/index.ts
+++ b/backend/shared/db/index.ts
@@ -15,5 +15,17 @@ function createDb(): AppDb {
   return drizzle(client, { schema });
 }
 
-export const db: AppDb = globalThis.__db ?? createDb();
-if (process.env.NODE_ENV !== 'production') globalThis.__db = db;
+function getDb(): AppDb {
+  const cached = globalThis.__db ?? createDb();
+  if (process.env.NODE_ENV !== 'production') globalThis.__db = cached;
+  return cached;
+}
+
+// db 를 lazy 로 초기화한다. 모듈이 로드되는 것만으로 DB 연결을 시도하면,
+// 빌드의 "페이지 데이터 수집" 단계처럼 DATABASE_URL 이 없는 컨텍스트에서
+// 전체 빌드가 실패한다. 실제 쿼리(프로퍼티 접근) 시점에만 연결을 생성한다.
+export const db: AppDb = new Proxy({} as AppDb, {
+  get(_target, prop, receiver) {
+    return Reflect.get(getDb() as object, prop, receiver);
+  },
+});

--- a/src/features/news/components/NewsArticleCard/NewsArticleCard.module.css
+++ b/src/features/news/components/NewsArticleCard/NewsArticleCard.module.css
@@ -91,16 +91,22 @@
 }
 
 .tag {
-  display: inline;
-  padding: 2px 8px;
+  display: inline-block;
+  /* 제목 텍스트 라인 중앙에 맞춰 태그 상·하단이 잘리지 않게 한다 */
+  vertical-align: middle;
+  /* 태그 자체 높이를 제목 line-height(24px) 안에 들어오도록 억제 */
+  line-height: 18px;
+  padding: 1px 8px;
   border-radius: 6px;
   border: 1px solid transparent;
   font-family: var(--font-pretendard), sans-serif;
   font-size: 14px;
   font-weight: 400;
-  line-height: 20px;
   white-space: nowrap;
   margin-right: 8px;
+  /* clamp 라인 박스에서 살짝 위로 올려 baseline 흔들림 보정 */
+  position: relative;
+  top: -1px;
 }
 
 .tag_company {

--- a/src/features/news/components/NewsArticleDetail/NewsArticleDetail.module.css
+++ b/src/features/news/components/NewsArticleDetail/NewsArticleDetail.module.css
@@ -286,6 +286,12 @@
   .htmlContent {
     font-size: 18px;
   }
+
+  /* 리스트도 본문과 동일한 크기로 축소 (기본 20px → 18px) */
+  .htmlContent ul,
+  .htmlContent ol {
+    font-size: 18px;
+  }
 }
 
 /* --- Mobile (≤ 799px) --- */
@@ -324,6 +330,20 @@
 
   .htmlContent p {
     margin-bottom: 16px;
+  }
+
+  /* 리스트도 본문과 동일한 크기로 축소 (기본 20px → 16px) */
+  .htmlContent ul,
+  .htmlContent ol {
+    font-size: 16px;
+  }
+
+  /* 소제목(h1~h3)도 모바일 크기로 축소 */
+  .htmlContent h1,
+  .htmlContent h2,
+  .htmlContent h3 {
+    font-size: 20px;
+    line-height: 32px;
   }
 
   /* 모바일: 본문 이미지를 문단 폭에 꽉 차게 */


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- DB 연결 지연 초기화로 빌드 실패 방지

- 모바일 뉴스 카드 태그 하단 잘림 현상 수정

- 모바일/태블릿 본문 리스트 글자 크기 축소

- 모바일 본문 소제목 글자 크기 축소


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix, enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>DB 연결 지연 초기화 구현</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/shared/db/index.ts

<li><code>db</code> 연결을 <code>Proxy</code>를 사용하여 지연 초기화하도록 변경했습니다.<br> <li> <code>getDb</code> 함수를 도입하여 DB 클라이언트 캐싱 및 생성 로직을 캡슐화했습니다.<br> <li> <code>DATABASE_URL</code> 환경 변수가 없는 빌드 단계에서 전체 빌드가 실패하는 문제를 해결했습니다.


</details>


  </td>
  <td><a href="https://github.com/Digitalpresso-ai/digitalpresso-homepage/pull/80/files#diff-825ea1a4b8a5884a12599a8546d4dec89bbf9715310ccd0d2e6f777e9c56ba6b">+14/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix, ui fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NewsArticleCard.module.css</strong><dd><code>모바일 뉴스 카드 태그 표시 오류 수정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/features/news/components/NewsArticleCard/NewsArticleCard.module.css

<li><code>.tag</code>의 <code>display</code>를 <code>inline-block</code>으로 변경하여 레이아웃을 개선했습니다.<br> <li> <code>vertical-align: middle</code> 및 <code>line-height</code> 조정을 통해 태그가 제목 라인 중앙에 오도록 수정했습니다.<br> <li> <code>padding</code> 및 <code>position</code> 조정을 통해 모바일에서 태그 하단 잘림 현상을 해결했습니다.


</details>


  </td>
  <td><a href="https://github.com/Digitalpresso-ai/digitalpresso-homepage/pull/80/files#diff-17be6463725dca38401c1fe1cbe9eeca1c0921e4bf94dcbc2b64def2a19c6de5">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix, responsive design, ui fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NewsArticleDetail.module.css</strong><dd><code>모바일/태블릿 뉴스 본문 글자 크기 반응형 조정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/features/news/components/NewsArticleDetail/NewsArticleDetail.module.css

<li>태블릿(<code>800px</code> ~ <code>1199px</code>)에서 본문 리스트(<code>ul</code>, <code>ol</code>)의 글자 크기를 <code>18px</code>로 통일했습니다.<br> <li> 모바일(<code>≤ 799px</code>)에서 본문 리스트(<code>ul</code>, <code>ol</code>)의 글자 크기를 <code>16px</code>로 통일했습니다.<br> <li> 모바일에서 본문 소제목(<code>h1</code>~<code>h3</code>)의 글자 크기를 <code>20px</code>로 축소하고 <code>line-height</code>를 조정했습니다.


</details>


  </td>
  <td><a href="https://github.com/Digitalpresso-ai/digitalpresso-homepage/pull/80/files#diff-2a634536c40c90373175408c74e653f71c2a80144933eb4a10dbbec7aed66c56">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>