### PR TITLE
Develop

### DIFF
--- a/backend/shared/db/index.ts
+++ b/backend/shared/db/index.ts
@@ -11,13 +11,19 @@ declare global {
 function createDb(): AppDb {
   const url = process.env.DATABASE_URL;
   if (!url) throw new Error('DATABASE_URL 환경변수가 필요합니다.');
-  const client = postgres(url, { prepare: false });
+  // 서버리스(Vercel Fluid Compute)에서는 함수 인스턴스가 여러 개 뜨므로,
+  // 인스턴스마다 풀을 크게 잡으면 DB 의 최대 연결 수(예: 200)를 금방 초과한다.
+  // max:1 로 인스턴스당 연결을 최소화하고, 유휴 연결은 곧 반납한다.
+  // (DATABASE_URL 은 Supabase 트랜잭션 풀러(6543 포트)를 가리켜야 한다.)
+  const client = postgres(url, { prepare: false, max: 1, idle_timeout: 20 });
   return drizzle(client, { schema });
 }
 
 function getDb(): AppDb {
+  // 프로덕션에서도 인스턴스 내에서 풀을 재사용해야 매 요청마다 새 연결을
+  // 만들지 않는다. globalThis 캐싱을 환경 무관하게 적용한다.
   const cached = globalThis.__db ?? createDb();
-  if (process.env.NODE_ENV !== 'production') globalThis.__db = cached;
+  globalThis.__db = cached;
   return cached;
 }
 


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- 서버리스 인스턴스당 DB 연결 풀을 `max:1`로 축소

- 유휴 연결을 `idle_timeout:20`으로 조기 반환

- `globalThis` 캐싱을 프로덕션에서도 적용하여 풀 재사용

- 서버리스 환경에서 DB 연결 한도 초과 문제 해결


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>DB 연결 풀 설정 및 캐싱 로직 개선</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/shared/db/index.ts

<li><code>postgres</code> 클라이언트 초기화 시 연결 풀 <code>max: 1</code> 및 <code>idle_timeout: 20</code> 옵션을 추가했습니다.<br> <li> <code>globalThis.__db</code> 캐싱 로직을 수정하여 프로덕션 환경에서도 DB 연결 풀을 재사용하도록 변경했습니다.<br> <li> 서버리스 환경에서 DB 연결 한도 초과를 방지하고 리소스 효율성을 높였습니다.


</details>


  </td>
  <td><a href="https://github.com/Digitalpresso-ai/digitalpresso-homepage/pull/82/files#diff-825ea1a4b8a5884a12599a8546d4dec89bbf9715310ccd0d2e6f777e9c56ba6b">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>